### PR TITLE
Excise bigint from nft-bridge dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,16 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea908e7347a8c64e378c17e30ef880ad73e3b4498346b055c2c00ea342f3179"
 
 [[package]]
-name = "bigint"
-version = "4.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
-dependencies = [
- "byteorder",
- "crunchy 0.1.6",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,12 +121,6 @@ checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 
 [[package]]
 name = "crunchy"
@@ -588,7 +572,6 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 name = "nft-bridge"
 version = "0.1.0"
 dependencies = [
- "bigint",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw721",
@@ -862,7 +845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "byteorder",
- "crunchy 0.2.2",
+ "crunchy",
  "hex",
  "static_assertions",
 ]

--- a/contracts/nft-bridge/Cargo.toml
+++ b/contracts/nft-bridge/Cargo.toml
@@ -13,7 +13,6 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-bigint = "4"
 cosmwasm-std = "1.0.0"
 cosmwasm-storage = { version = "1.0.0" }
 cw721 = { path = "../../packages/cw721" }

--- a/contracts/nft-bridge/src/token_id.rs
+++ b/contracts/nft-bridge/src/token_id.rs
@@ -1,6 +1,6 @@
-use bigint::U256;
-use cosmwasm_std::{StdError, StdResult, Storage};
+use std::str::FromStr;
 
+use cosmwasm_std::{StdResult, Storage, Uint256};
 use sha3::digest::consts::U32;
 use sha3::digest::generic_array::GenericArray;
 use sha3::{Digest, Keccak256};
@@ -52,7 +52,7 @@ pub fn from_external_token_id(
     if nft_chain == CHAIN_ID {
         token_id_hashes_read(storage, nft_chain, *nft_address).load(token_id_external)
     } else {
-        Ok(format!("{}", U256::from_big_endian(token_id_external)))
+        Ok(format!("{}", Uint256::from_be_bytes(*token_id_external)))
     }
 }
 
@@ -73,15 +73,6 @@ pub fn to_external_token_id(
         token_id_hashes(storage, nft_chain, *nft_address).save(&hash, &token_id_internal)?;
         Ok(hash.as_slice().get_const_bytes(0))
     } else {
-        let mut bytes = [0; 32];
-        U256::from_dec_str(&token_id_internal)
-            .map_err(|_| {
-                StdError::generic_err(format!(
-                    "{} could not be parsed as a decimal number",
-                    token_id_internal
-                ))
-            })?
-            .to_big_endian(&mut bytes);
-        Ok(bytes)
+        Ok(Uint256::from_str(&token_id_internal)?.to_be_bytes())
     }
 }


### PR DESCRIPTION
https://github.com/palomachain/paloma/issues/177

## Background

`bigint` is unmaintained and Uint256 is preferred within the cosmwasm
ecosystem.

## Testing completed

- [x] Existing tests pass

